### PR TITLE
eslintの「Missing return type on function」をエラーに

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -16,6 +16,7 @@ plugins:
   - '@typescript-eslint'
 rules:
   'react/react-in-jsx-scope': 0
+  '@typescript-eslint/explicit-module-boundary-types': 2
 settings:
   react:
     version: 'detect'

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -4,7 +4,7 @@ type Props = {
   title: string;
 };
 
-const Footer = ({ title }: Props) => {
+const Footer = ({ title }: Props): JSX.Element => {
   return (
     <>
       <footer className={styles.footer}>


### PR DESCRIPTION
## 関連 Issue

Fixes #22 
